### PR TITLE
Prevent infinite loop when paused and never resumed

### DIFF
--- a/bufferedstream.js
+++ b/bufferedstream.js
@@ -202,6 +202,7 @@ BufferedStream.prototype.end = function (chunk, encoding) {
  */
 BufferedStream.prototype._emitEndDestroyNextTick = function () {
   var self = this;
+
   process.nextTick(function tick() {
     if (self.empty) {
       self.destroy();

--- a/bufferedstream_test_noloop.js
+++ b/bufferedstream_test_noloop.js
@@ -1,0 +1,39 @@
+
+/*
+ * This test is simply run manually to verify it doesn't peg CPU
+ *
+ * node bufferedstream_test_noloop.js
+ *
+ * While it is running, manually verify CPU with top or another monitor
+ * and it should not be pegged at 100%
+ *
+ * The test exits regardless of outcome after one minute
+ *
+ */
+
+var BufferedStream = require("./bufferedstream");
+
+var bs1 = new BufferedStream('Hello world');
+bs1.pause();
+
+var bs2 = new BufferedStream('');
+bs2.pause();
+
+var bs3 = new BufferedStream();
+bs3.pause();
+bs3.write('Hello world');
+
+var bs4 = new BufferedStream();
+bs4.pause();
+bs4.write('');
+
+var bs5 = new BufferedStream();
+bs5.pause();
+bs5.end('Hello world');
+
+var bs6 = new BufferedStream();
+bs6.pause();
+bs6.end('');
+
+console.warn('Created buffered streams, and if working properly this should exit on its own quickly');
+console.warn("If it doesn't then it is probably in an infinate loop, use control-c to terminate");


### PR DESCRIPTION
If a BufferedStream is created, paused, and content written to it via
constructor, write, or end without resume() ever being called,
BufferedStream will go into an infinate loop.

I created a test file you can run to verify.  Without the fix, the test
never finishes and CPU hits 100%. With the fix the test 
completes as expected.

The fix is to exit out of the process.next loops if it is paused
and then add triggers in resume() to do the work if necessary

Any of the following examples would have previously caused
an infinite loop if the stream was never resumed.

``` javascript
var BufferedStream = require("./bufferedstream");

var bs1 = new BufferedStream('Hello world');
bs1.pause();

var bs2 = new BufferedStream('');
bs2.pause();

var bs3 = new BufferedStream();
bs3.pause();
bs3.write('Hello world');

var bs4 = new BufferedStream();
bs4.pause();
bs4.write('');

var bs5 = new BufferedStream();
bs5.pause();
bs5.end('Hello world');

var bs6 = new BufferedStream();
bs6.pause();
bs6.end('');
```
