### PR TITLE
use setImmediate rather than process.nextTick if available

### DIFF
--- a/buffered-stream.js
+++ b/buffered-stream.js
@@ -1,5 +1,10 @@
 var util = require('util');
 var Stream = require('stream');
+// node 0.10.0 changes nextTick to occur before IO, use 0.10's setImmediate,
+// otherwise for older versions of node use process.nextTick
+var setImmediateOrNextTick = (typeof setImmediate === 'function') ?
+                             setImmediate :
+                             process.nextTick;
 
 module.exports = BufferedStream;
 
@@ -139,7 +144,7 @@ function flushOnNextTick(stream) {
   if (stream._flushing) return;
   stream._flushing = true;
 
-  process.nextTick(function tick() {
+  setImmediateOrNextTick(function tick() {
     if (stream.paused) {
       stream._flushing = false;
       return;
@@ -150,7 +155,7 @@ function flushOnNextTick(stream) {
     if (stream.empty) {
       stream._flushing = false;
     } else {
-      process.nextTick(tick);
+      setImmediateOrNextTick(tick);
     }
   });
 }


### PR DESCRIPTION
mjijackson/bufferedstream#6

Node 0.10 changes process.nextTick to occur before IO so
we should use its setImmediate instead, but to make this
backward compatible, check for the existence of setImmediate
and use it otherwise fallback to process.nextTick on older
versions of Node.
